### PR TITLE
Make it build on clang

### DIFF
--- a/ppmdu_2/include/ppmdu/containers/tiled_image.hpp
+++ b/ppmdu_2/include/ppmdu/containers/tiled_image.hpp
@@ -629,7 +629,7 @@ namespace gimg
         // --> Inverting pixel order on pixels that overflow over several bytes isn't supported right now !! <--
         if( invertpixelorder && (_TILED_IMG_T::pixel_t::GetBitsPerPixel() > 8) && (8u % _TILED_IMG_T::pixel_t::GetBitsPerPixel()) != 0 )
         {
-            throw std::exception( "WriteTiledImg(): Inverting pixel order on pixels that overflow over one or several bytes isn't supported right now !!" ); //#TODO: Specialize the temtplate when needed!
+            throw std::runtime_error( "WriteTiledImg(): Inverting pixel order on pixels that overflow over one or several bytes isn't supported right now !!" ); //#TODO: Specialize the template when needed!
         }
 
         typedef _TILED_IMG_T                  image_t;

--- a/ppmdu_2/include/ppmdu/pmd2/pmd2_asm_data.hpp
+++ b/ppmdu_2/include/ppmdu/pmd2/pmd2_asm_data.hpp
@@ -1,5 +1,5 @@
 #ifndef PMD2_ASM_DATA_HPP
-#define PMD2_ADM_DATA_HPP
+#define PMD2_ASM_DATA_HPP
 /*
 pmd2_asm_data.hpp
 2016/05/09

--- a/ppmdu_2/include/utils/common_suffixes.hpp
+++ b/ppmdu_2/include/utils/common_suffixes.hpp
@@ -1,21 +1,12 @@
 #include <cstdint>
-#ifndef _MSC_BUILD
-    #if __GNUG__
-        //Get rid of the warning for the suffix not having an underscore, since this is a substitution for MSVC.
-        //If suffix names matching those ever get used, they'll make the compiler complain about duplicate definitions anyways.
-        #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Wliteral-suffix"
-    #endif
-constexpr uint8_t  operator"" ui8 (unsigned long long literal_) {return literal_;}
-constexpr uint16_t operator"" ui16(unsigned long long literal_) {return literal_;}
-constexpr uint32_t operator"" ui32(unsigned long long literal_) {return literal_;}
-constexpr uint64_t operator"" ui64(unsigned long long literal_) {return literal_;}
 
-constexpr int8_t  operator"" i8 (unsigned long long literal_){return literal_;}
-constexpr int16_t operator"" i16(unsigned long long literal_){return literal_;}
-constexpr int32_t operator"" i32(unsigned long long literal_){return literal_;}
-constexpr int64_t operator"" i64(unsigned long long literal_){return literal_;}
-    #if __GNUG__
-        #pragma GCC diagnostic pop
-    #endif
-#endif // !_MSC_BUILD
+// Underscore-prefixed versions of the MSVC literal suffixes, which are more portable
+constexpr uint8_t  operator"" _ui8 (unsigned long long literal_) {return literal_;}
+constexpr uint16_t operator"" _ui16(unsigned long long literal_) {return literal_;}
+constexpr uint32_t operator"" _ui32(unsigned long long literal_) {return literal_;}
+constexpr uint64_t operator"" _ui64(unsigned long long literal_) {return literal_;}
+
+constexpr int8_t  operator"" _i8 (unsigned long long literal_){return literal_;}
+constexpr int16_t operator"" _i16(unsigned long long literal_){return literal_;}
+constexpr int32_t operator"" _i32(unsigned long long literal_){return literal_;}
+constexpr int64_t operator"" _i64(unsigned long long literal_){return literal_;}

--- a/ppmdu_2/include/utils/gbyteutils.hpp
+++ b/ppmdu_2/include/utils/gbyteutils.hpp
@@ -11,6 +11,7 @@ A bunch of simple tools for doing common tasks when manipulating bytes.
 
 //!#TODO: this needs a serious cleanup!!
 #include <vector>
+#include <string>
 #include <cstdint>
 #include <limits>
 #include <type_traits>

--- a/ppmdu_2/src/dse/dse_interpreter.cpp
+++ b/ppmdu_2/src/dse/dse_interpreter.cpp
@@ -1001,7 +1001,7 @@ namespace DSE
                 auto itfound = m_convtable->FindConversionInfo(state.origdseprgm_);
 
                 if( itfound != m_convtable->end() && itfound->second.maxkeydowndur != 0 )
-                    noteofftime = state.ticks_ +  utils::Clamp( state.lasthold_, 0ui32, itfound->second.maxkeydowndur );
+                    noteofftime = state.ticks_ +  utils::Clamp( state.lasthold_, 0_ui32, itfound->second.maxkeydowndur );
             }
 
             if( utils::LibWide().isLogOn() && utils::LibWide().isVerboseOn() )

--- a/ppmdu_2/src/ext_fmts/adpcm.cpp
+++ b/ppmdu_2/src/ext_fmts/adpcm.cpp
@@ -213,7 +213,7 @@ namespace audio
             {
                 //Read two 4 bits samples
                 uint8_t          curbuff = ReadIntFromBytes<int8_t>(m_itread,m_data.end()); //iterator is incremented 
-                array<int8_t, 2> smpls   = {static_cast<int8_t>(curbuff & 0x0Fui8), static_cast<int8_t>((curbuff >> 4) & 0x0Fui8) };
+                array<int8_t, 2> smpls   = {static_cast<int8_t>(curbuff & 0x0F_ui8), static_cast<int8_t>((curbuff >> 4) & 0x0F_ui8) };
 
                 //Decode them
                 for(auto & smpl : smpls)

--- a/ppmdu_2/src/ppmdu/fmts/bgp.cpp
+++ b/ppmdu_2/src/ppmdu/fmts/bgp.cpp
@@ -46,10 +46,10 @@ namespace filetypes
     private:
         static BGP::tilemapdata DecodeTileMappingData( uint16_t entry )
         {
-            return move( BGP::tilemapdata{  static_cast<uint16_t>(entry & 0x3FFui16),       //0000 0011 1111 1111, tile index
+            return move( BGP::tilemapdata{  static_cast<uint16_t>(entry & 0x3FF_ui16),       //0000 0011 1111 1111, tile index
                                             static_cast<uint8_t>((entry & 0xF000) >> 12),   //1111 0000 0000 0000, pal index
-                                            (entry & 0x800ui16) > 0,                        //0000 1000 0000 0000, vflip
-                                            (entry & 0x400ui16) > 0} );                     //0000 0100 0000 0000, hflip 
+                                            (entry & 0x800_ui16) > 0,                        //0000 1000 0000 0000, vflip
+                                            (entry & 0x400_ui16) > 0} );                     //0000 0100 0000 0000, hflip
         }
 
         void DoParse()

--- a/ppmdu_2/src/ppmdu/fmts/ssa.cpp
+++ b/ppmdu_2/src/ppmdu/fmts/ssa.cpp
@@ -290,7 +290,7 @@ namespace filetypes
     {
         static const size_t LEN        = 20;
         static const size_t LENPadding = 4;
-        constexpr int8_t PadByte()const { return 0xFFi8; }
+        constexpr int8_t PadByte()const { return 0xFF_i8; }
 
         int16_t type;
         int16_t facing;   

--- a/ppmdu_2/src/utils/cmdline_util.cpp
+++ b/ppmdu_2/src/utils/cmdline_util.cpp
@@ -26,7 +26,7 @@ namespace utils{ namespace cmdl
     {
 #ifdef WIN32
         m_nullbuff.open( "nul", std::ios::out );
-#elif __linux__
+#else
         m_nullbuff.open( "/dev/null", std::ios::out );
 #endif
         m_oldbuf = std::clog.rdbuf( &m_nullbuff );

--- a/ppmdu_audioutil/src/audioutil.cpp
+++ b/ppmdu_audioutil/src/audioutil.cpp
@@ -88,7 +88,7 @@ namespace audioutil
             "Path to the file/directory to export, or the directory to assemble.",
 #ifdef WIN32
             "\"c:/pmd_romdata/data.bin\"",
-#elif __linux__
+#else
             "\"/pmd_romdata/data.bin\"",
 #endif
             std::bind( &CAudioUtil::ParseInputPath,       &GetInstance(), placeholders::_1 ),
@@ -103,7 +103,7 @@ namespace audioutil
             "Output path. The result of the operation will be placed, and named according to this path!",
 #ifdef WIN32
             "\"c:/pmd_romdata/data\"",
-#elif __linux__
+#else
             "\"/pmd_romdata/data\"",
 #endif
             std::bind( &CAudioUtil::ParseOutputPath,       &GetInstance(), placeholders::_1 ),

--- a/ppmdu_gfxcrunch/src/gfxcrunch.cpp
+++ b/ppmdu_gfxcrunch/src/gfxcrunch.cpp
@@ -297,7 +297,7 @@ namespace gfx_util
             "Path to an additional item to process.",
 #ifdef WIN32
             "\"c:/mysprites/sprite.wan\"",
-#elif __linux__
+#else
             "\"/mysprites/sprite.wan\"",
 #endif
             std::bind( &CGfxUtil::ParseExtraPath, &GetInstance(), placeholders::_1 ),
@@ -318,7 +318,7 @@ namespace gfx_util
             "The path to either a folder structure containing the data of a sprite to build, or a sprite file to unpack.",
 #ifdef WIN32
             "\"c:/mysprites/sprite.wan\"",
-#elif __linux__
+#else
             "\"/mysprites/sprite.wan\"",
 #endif
             std::bind( &CGfxUtil::ParseInputPath, &GetInstance(), placeholders::_1 ),
@@ -332,7 +332,7 @@ namespace gfx_util
             "The path where to output the result of the operation. Can be a folder, or a file, depending on whether we're building a sprite, or unpacking one.",
 #ifdef WIN32
             "\"c:/mysprites/sprite.wan\"",
-#elif __linux__
+#else
             "\"/mysprites/sprite.wan\"",
 #endif
             std::bind( &CGfxUtil::ParseOutputPath,       &GetInstance(), placeholders::_1 ),

--- a/ppmdu_statsutil/src/statsutil.cpp
+++ b/ppmdu_statsutil/src/statsutil.cpp
@@ -78,7 +78,7 @@ namespace statsutil
             "Path to the file to export, or the directory to assemble.",
 #ifdef WIN32
             "\"c:/pmd_romdata/data.bin\"",
-#elif __linux__
+#else
             "\"/pmd_romdata/data.bin\"",
 #endif
             std::bind( &CStatsUtil::ParseInputPath, &GetInstance(), placeholders::_1 ),
@@ -92,7 +92,7 @@ namespace statsutil
             "Output path. The result of the operation will be placed, and named according to this path!",
 #ifdef WIN32
             "\"c:/pmd_romdata/data\"",
-#elif __linux__
+#else
             "\"/pmd_romdata/data\"",
 #endif
             std::bind( &CStatsUtil::ParseOutputPath,       &GetInstance(), placeholders::_1 ),


### PR DESCRIPTION
Assortment of minor changes to make things build with clang (on macOS).
- Add more standard `#include`s
- std::exception has no constructor that takes a string literal, use `std::runtime_error` instead.
- Don't use the MSVC integer literal suffixes, which aren't portable (and discouraged by Microsoft: https://stackoverflow.com/a/33678372). Warnings can be suppressed on gcc with `-Wno-literal-suffix`, but clang appears to use a different warning (`-Wuser-defined-literals`), and states that "no literal will invoke this operator". It seems to ignore the definitions entirely. It's easier to just switch to using standard-conforming suffixes that start with an underscore.
- Replace `#elif __linux__` with a simple `#else`. `__linux__` is GCC-specific, and also won't work with other Unix OSs.

It won't necessarily run properly, but it at least builds now ¯\\\_(ツ)\_/¯.