### PR TITLE
Small fixes to install poco correctly and compile on modern GCC

### DIFF
--- a/ppmdu_2/include/utils/pugixml_utils.hpp
+++ b/ppmdu_2/include/utils/pugixml_utils.hpp
@@ -11,6 +11,7 @@ Description:
 #include <string>
 #include <pugixml.hpp>
 #include <codecvt>
+#include <cstdint>
 #include <locale>
 #include <sstream>
 

--- a/ppmdu_2/src/ppmdu/pmd2/pmd2_scripts_xml_io.cpp
+++ b/ppmdu_2/src/ppmdu/pmd2/pmd2_scripts_xml_io.cpp
@@ -9,11 +9,13 @@
 #include <ppmdu/pmd2/pmd2_scripts_opcodes.hpp>
 #include <ppmdu/pmd2/pmd2_xml_sniffer.hpp>
 #include <utils/pugixml_utils.hpp>
+#include <string.h>
 #include <utils/library_wide.hpp>
 //#include <utils/multiple_task_handler.hpp>
 #include <utils/parallel_tasks.hpp>
 #include <ppmdu/fmts/ssb.hpp>
 #include <atomic>
+#include <functional>
 #include <thread>
 #include <unordered_set>
 #include <Poco/DirectoryIterator.h>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,12 @@
   "name": "ppmdu-2",
   "version": "1.0.0",
   "dependencies": [
-    "poco",
+    {
+      "name": "poco",
+      "features": [
+        "util"
+      ]
+    },
     "libpng",
     "zlib",
     "pugixml"


### PR DESCRIPTION
Updated vcpkg to install Poco Util module in addition to core. Fixed include directives to compile correctly.
