### PR TITLE
Revert "Small fixes to install poco correctly and compile on modern GCC"

### DIFF
--- a/ppmdu_2/include/utils/pugixml_utils.hpp
+++ b/ppmdu_2/include/utils/pugixml_utils.hpp
@@ -11,7 +11,6 @@ Description:
 #include <string>
 #include <pugixml.hpp>
 #include <codecvt>
-#include <cstdint>
 #include <locale>
 #include <sstream>
 

--- a/ppmdu_2/src/ppmdu/pmd2/pmd2_scripts_xml_io.cpp
+++ b/ppmdu_2/src/ppmdu/pmd2/pmd2_scripts_xml_io.cpp
@@ -9,13 +9,11 @@
 #include <ppmdu/pmd2/pmd2_scripts_opcodes.hpp>
 #include <ppmdu/pmd2/pmd2_xml_sniffer.hpp>
 #include <utils/pugixml_utils.hpp>
-#include <string.h>
 #include <utils/library_wide.hpp>
 //#include <utils/multiple_task_handler.hpp>
 #include <utils/parallel_tasks.hpp>
 #include <ppmdu/fmts/ssb.hpp>
 #include <atomic>
-#include <functional>
 #include <thread>
 #include <unordered_set>
 #include <Poco/DirectoryIterator.h>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,12 +2,7 @@
   "name": "ppmdu-2",
   "version": "1.0.0",
   "dependencies": [
-    {
-      "name": "poco",
-      "features": [
-        "util"
-      ]
-    },
+    "poco",
     "libpng",
     "zlib",
     "pugixml"


### PR DESCRIPTION
Reverts PsyCommando/ppmdu_2#11
Something went wrong with the vcpkg.json config and poco.